### PR TITLE
Force down Ascensio

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -19,7 +19,7 @@
     "utility_list": false,
     "image_contains_title": true,
     "DisplayVersionOnlyInInstallerView": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "image": "https://raw.githubusercontent.com/Oghma-Infinium/Ascensio/main/Media/Ascensio%20WJ%20Header.webp",
       "readme": "https://raw.githubusercontent.com/Oghma-Infinium/Ascensio/main/README.md",


### PR DESCRIPTION
due to personal reasons bingus is unable to handle the list at the moment.

Forcing down the list while she is absent to ease support burden.